### PR TITLE
foreskrift: detect repeal relations in BOLFS titles

### DIFF
--- a/ferenda/foreskrift/parse.py
+++ b/ferenda/foreskrift/parse.py
@@ -644,8 +644,10 @@ def extract_metadata(text, declaration, parser):
     # _fs_key, not lower(): 'ÅFS' must mint aafs/…, never a dangling åfs/…
     targets = [m.group(1) for m in RE_ERSATTER.finditer(text)]
     targets += [RE_ANDRING.split(m.group(1))[0] for m in RE_UPPHORA.finditer(text)]
-    # the noun form in the declaration (masthead + harvest title)
-    targets += [m.group(1) for m in RE_UPPHAVANDE.finditer(declaration)]
+    # the noun form in the declaration (masthead + harvest title), cut the same
+    # way: "upphävande av X (HSLF-FS 2019:43) om ändring i Y (HSLF-FS 2019:32)"
+    # repeals the amendment X, and Y stays in force
+    targets += [RE_ANDRING.split(m.group(1))[0] for m in RE_UPPHAVANDE.finditer(declaration)]
     meta["upphaver"] = sorted({regulation_uri(_fs_key(fs), y, str(int(n)))
                                for target in targets
                                for fs, y, n in RE_FS_REF.findall(target)})

--- a/ferenda/foreskrift/parse.py
+++ b/ferenda/foreskrift/parse.py
@@ -167,6 +167,8 @@ def stodav_clause(text):
 # passive ("Genom föreskrifterna upphävs … (PMFS 2019:2)")
 RE_ERSATTER = re.compile(r"\b(?:ersätter|upphäv(?:er|s))\b(.*?)(?:\.|$)",
                          re.DOTALL | re.I)
+# noun form in a title ("föreskrift om upphävande av … (BOLFS 2006:1)")
+RE_UPPHAVANDE = re.compile(r"\bupphävande\s+av\b(.*?)(?:\.|$)", re.DOTALL | re.I)
 RE_FS_REF = re.compile(r"\b([A-ZÅÄÖ]+-?FS)\s*(\d{4}):(\d+)")   # NFS/TFS … ELSÄK-FS
 # an ändringsförfattning's own title names its target: "… föreskrifter om
 # ändring i <agency>s föreskrifter (ÅFS 2005:5) om …". Some agencies drop
@@ -618,12 +620,15 @@ def extract_metadata(text, declaration, parser):
         if dirs:
             genomfor.add(min(dirs, key=lambda r: r.start).uri)
     meta["genomfor"] = sorted(genomfor)
-    # upphäver: regulations an "ersätter/upphäver(s) …" clause replaces --
+    # upphäver: regulations an "ersätter/upphäver(s) …" PDF clause or an
+    # "upphävande av …" title replaces. The declaration includes the harvest title.
     # every clause, since the first "upphävs" in a document is often a bare
     # provision repeal ("5 § upphävs") that names no regulation at all.
     # _fs_key, not lower(): 'ÅFS' must mint aafs/…, never a dangling åfs/…
     meta["upphaver"] = sorted({regulation_uri(_fs_key(fs), y, str(int(n)))
-                               for m in RE_ERSATTER.finditer(text)
+                               for pattern, source in ((RE_ERSATTER, text),
+                                                       (RE_UPPHAVANDE, declaration))
+                               for m in pattern.finditer(source)
                                for fs, y, n in RE_FS_REF.findall(m.group(1))})
     return meta
 

--- a/test/test_foreskrift_parse.py
+++ b/test/test_foreskrift_parse.py
@@ -342,6 +342,21 @@ def test_extract_metadata_upphaver_folds_designation_to_the_fs_slug():
     assert meta["upphaver"] == ["https://lagen.nu/aafs/2005:6"]
 
 
+def test_extract_metadata_upphaver_from_harvest_title():
+    # BOLFS 2022:3 and 2022:4 declare the repeal only with the noun form in
+    # their harvest titles. Their PDF text instead says "ska upphöra att gälla".
+    parser = sfs_parser("foreskrift", PARSE_TYPES)
+    for title, target in [
+            ("Föreskrift om upphävande av Bolagsverkets föreskrifter "
+             "(BOLFS 2006:1) om avgifter för bevis",
+             "https://lagen.nu/bolfs/2006:1"),
+            ("Föreskrift om upphävande av Bolagsverkets föreskrifter "
+             "(BOLFS 2006:2) om avgifter för bevis och uppgifter",
+             "https://lagen.nu/bolfs/2006:2")]:
+        meta = extract_metadata("", fp.role_declaration("", title), parser)
+        assert meta["upphaver"] == [target]
+
+
 def test_printed_designation_names_a_regulation_the_corpus_does_not_hold():
     # a repealed predecessor series nobody harvests still has to be *named* in
     # the Upphäver row; without this the reader was shown the slug

--- a/test/test_foreskrift_parse.py
+++ b/test/test_foreskrift_parse.py
@@ -375,8 +375,10 @@ def test_extract_metadata_upphaver_folds_designation_to_the_fs_slug():
 
 
 def test_extract_metadata_upphaver_from_harvest_title():
-    # BOLFS 2022:3 and 2022:4 declare the repeal only with the noun form in
-    # their harvest titles. Their PDF text instead says "ska upphöra att gälla".
+    # BOLFS 2022:3 and 2022:4 declare the repeal with the noun form in their
+    # harvest titles (their PDF text says "ska upphöra att gälla", which the
+    # decision form reads too); the title alone must yield the relation, since
+    # for 949 föreskrifter on lagen.nu it is the only readable statement of it
     parser = sfs_parser("foreskrift", PARSE_TYPES)
     for title, target in [
             ("Föreskrift om upphävande av Bolagsverkets föreskrifter "
@@ -387,6 +389,18 @@ def test_extract_metadata_upphaver_from_harvest_title():
              "https://lagen.nu/bolfs/2006:2")]:
         meta = extract_metadata("", fp.role_declaration("", title), parser)
         assert meta["upphaver"] == [target]
+
+
+def test_title_upphavande_of_an_amendment_spares_its_base():
+    # HSLF-FS 2021:26 repeals the ändringsförfattning HSLF-FS 2019:43, whose
+    # own title names the base regulation HSLF-FS 2019:32; only the amendment
+    # is repealed, the base stays in force
+    title = ("Föreskrifter (HSLF-FS 2021:26) om upphävande av föreskrifterna "
+             "(HSLF-FS 2019:43) om ändring i Läkemedelsverkets föreskrifter "
+             "(HSLF-FS 2019:32) om förordnande och utlämnande av läkemedel")
+    meta = extract_metadata("", fp.role_declaration("", title),
+                            sfs_parser("foreskrift", PARSE_TYPES))
+    assert meta["upphaver"] == ["https://lagen.nu/hslffs/2019:43"]
 
 
 def test_printed_designation_names_a_regulation_the_corpus_does_not_hold():


### PR DESCRIPTION
Fixes #30

Summary:
- recognize the noun form upphävande av in regulation titles
- scan harvested title declarations for repeal targets
- cover BOLFS 2022:3 and BOLFS 2022:4 with a regression test

Checks:
- uv run --frozen pytest test/test_foreskrift_parse.py -q: 78 passed
- uv run --frozen ruff check ferenda/foreskrift/parse.py: passed
- uv run --frozen ty check ferenda/foreskrift/parse.py: passed
- full pytest: 4378 passed; three environment-dependent tests failed because OpenSearch disconnected, antiword is absent, and POI jars are absent